### PR TITLE
network: message log resolved NoneType error

### DIFF
--- a/core/network.py
+++ b/core/network.py
@@ -115,10 +115,11 @@ class Network:
             num_msgs = int(num_msgs)
         except ValueError:
             return None
-        r = self.unreads[:num_msgs]                             # Get num_msgs msgs from unreads
-        self.unreads = self.unreads[len(r):]                    # Remove from unreads
-        self.logged_messages = r.extend(
-            self.logged_messages[:self.buffer_size-len(r)][:])  # Add to the logged_messages
+        r = self.unreads[:num_msgs]                                 # Get num_msgs msgs from unreads
+        self.unreads = self.unreads[len(r):]                        # Remove from unreads
+        tmp = r[:]
+        tmp.extend(self.logged_messages[:self.buffer_size-len(r)][:])
+        self.logged_messages = tmp
         return r
 
 


### PR DESCRIPTION
Resolved NoneType error that was thrown because of trying to update
`logged_messages`. It turns out that the list.extend() method simply
extends the list in place, it doesn't return an extended list. There is
currently no visible error checking, however, tests done at the command
line indicate that python's splicing handles these OutOfBounds errors
for us.

Fixes #18