### PR TITLE
Changed network ip grabbing.

### DIFF
--- a/config/network.conf
+++ b/config/network.conf
@@ -1,5 +1,3 @@
 # Configuration file for network class
-ip : 192.168.1.2
 netmask : 255.255.255.255
-serial_number : 1
 port : 5005

--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -1,4 +1,5 @@
 import os
+import socket
 
 from config import settings
 
@@ -60,3 +61,17 @@ def remove_comment(line, comment_start):
         return line[:ind]
     except ValueError:
         return line
+
+
+def get_ip():
+    """
+    A method to get the ip address of this machine. Connects to address
+    8.8.8.8 (Google's public DNS) and then looks at the name of the
+    socket. Returns this as a string.
+    :return: A string representing the ip address of this machine.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.connect(("8.8.8.8", 80))
+    ip = sock.getsockname()[0]
+    sock.close()
+    return ip


### PR DESCRIPTION
Modified the `Network` class so that it reads this machine's ip address
instead of relying on a configuration file. Created a helper method in
`helpers.py` to make this look cleaner.

Network listening process (and conf)

Changed the `stop_listening()` method so that the process is actually
terminated. Now the `os` module sends a termination signal to the
listening process.
Changed the listening process to a daemon process so that it terminates
when it's parent process (the program) terminates. This allows for a
cleaner exit and means there won't be any zombie processes hanging
around preventing us from `bind`ing to the same ip address if we want to
run the program again.

Removed the `ip` address line from `network.conf` because we are now
reading the ip address directly from the socket.
Removed the `serial_number` line from `network.conf` because it wasn't
being used for anything.